### PR TITLE
feat: Show detailed information on invalid package description files

### DIFF
--- a/lib/parsePkg.nix
+++ b/lib/parsePkg.nix
@@ -9,16 +9,21 @@ let
     (alistToAttrs { emptyListToNull = true; })
   ];
 in
-rest
-  //
-{
-  ename = assert (head list == "define-package"); (elemAt list 1);
-  version = elemAt list 2;
-  summary = elemAt list 3;
-  packageRequires = lib.pipe (elemAt list 4) [
-    (lib.flip elemAt 1)
-    # I don't expect there is a package entry that lacks a version,
-    # so I don't care emptyListToNull for now.
-    (alistToAttrs { emptyListToNull = false; })
-  ];
-}
+if head list != "define-package"
+then throw "A package description file does not start with define-package: ${str}"
+else if length list < 5
+then throw "A package description file does not specify dependencies: ${str}"
+else
+  rest
+    //
+  {
+    ename = elemAt list 1;
+    version = elemAt list 2;
+    summary = elemAt list 3;
+    packageRequires = lib.pipe (elemAt list 4) [
+      (lib.flip elemAt 1)
+      # I don't expect there is a package entry that lacks a version,
+      # so I don't care emptyListToNull for now.
+      (alistToAttrs { emptyListToNull = false; })
+    ];
+  }


### PR DESCRIPTION
Some packages seem to contain an invalid *-pkg.el file. It would be better to display the content of the file to let the user know which package provides an invalid file (Example: https://github.com/jorgenschaefer/emacs-buttercup/issues/212).