### PR TITLE
Convert recipes with gitlab fetcher to gitlab type

### DIFF
--- a/lib/flakeRefAttrsFromMelpaRecipeAttrs.nix
+++ b/lib/flakeRefAttrsFromMelpaRecipeAttrs.nix
@@ -23,6 +23,15 @@ with builtins; let
       inherit owner repo;
     });
 
+  buildGitlabAttrs = {
+    owner,
+    repo,
+  }: (vcAttrs
+    // {
+      type = "gitlab";
+      inherit owner repo;
+    });
+
   buildSourceHutAttrs = {
     owner,
     repo,
@@ -51,6 +60,13 @@ in
       owner = elemAt repoPath 0;
       repo = elemAt repoPath 2;
     }
+  else if fetcher == "gitlab"
+  then
+    buildGitlabAttrs
+    {
+      owner = elemAt repoPath 0;
+      repo = elemAt repoPath 2;
+    }
   else if fetcher == "sourcehut"
   then
     buildSourceHutAttrs
@@ -63,12 +79,6 @@ in
     buildGitAttrs
     {
       url = "https://codeberg.org/${package.repo}.git";
-    }
-  else if fetcher == "gitlab"
-  then
-    buildGitAttrs
-    {
-      url = "https://gitlab.com/${package.repo}.git";
     }
   else if fetcher == "git"
   then

--- a/lib/flakeRefUrlFromFlakeRefAttrs.nix
+++ b/lib/flakeRefUrlFromFlakeRefAttrs.nix
@@ -33,6 +33,8 @@ in
   then "github:${attrs.owner}/${attrs.repo}" + branchSuffix + query
   else if type == "sourcehut"
   then "sourcehut:${attrs.owner}/${attrs.repo}" + branchSuffix + query
+  else if type == "gitlab"
+  then "gitlab:${attrs.owner}/${attrs.repo}" + branchSuffix + query
   else if type == "git"
   then toGitUrl url + query
   else if type == "mercurial"

--- a/test/test-flake-ref.nix
+++ b/test/test-flake-ref.nix
@@ -31,7 +31,7 @@ in
 
       testGitlab = {
         expr = flakeRefUrlFromMelpaRecipe (readFile ./gitlab-recipe);
-        expected = "git+https://gitlab.com/joewreschnig/gitlab-ci-mode.git";
+        expected = "gitlab:joewreschnig/gitlab-ci-mode";
       };
 
       testSourcehut = {

--- a/test/test-recipe.nix
+++ b/test/test-recipe.nix
@@ -8,6 +8,7 @@ in
     recipe3 = parseMelpaRecipe (readFile ./recipe3);
     recipe4 = parseMelpaRecipe (readFile ./recipe4);
     recipe5 = parseMelpaRecipe (readFile ./recipe5);
+    recipeGitlab = parseMelpaRecipe (readFile ./gitlab-recipe);
 
     excludeNulls = pkgs.lib.filterAttrs (_: val: val != null);
   in
@@ -71,6 +72,16 @@ in
           pname = "discover-my-major";
           fetcher = "git";
           url = "https://framagit.org/steckerhalter/discover-my-major.git";
+        };
+      };
+
+      testGitlabRecipe = {
+        expr = excludeNulls recipeGitlab;
+        expected = {
+          ename = "gitlab-ci-mode";
+          pname = "gitlab-ci-mode";
+          fetcher = "gitlab";
+          repo = "joewreschnig/gitlab-ci-mode";
         };
       };
     }


### PR DESCRIPTION
gitlab type is supported by Nix, and it's better to use a dedicated type wherever possible.